### PR TITLE
Development - Inventory Modifications

### DIFF
--- a/Assets/Prefabs/Slot.prefab
+++ b/Assets/Prefabs/Slot.prefab
@@ -34,8 +34,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 0.00021458, y: 0}
-  m_SizeDelta: {x: 226.02, y: 50}
+  m_AnchoredPosition: {x: 0.00021458, y: 4.7336}
+  m_SizeDelta: {x: 226.02, y: 59.4672}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &7973044005285796178
 CanvasRenderer:
@@ -92,8 +92,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 28
-  m_fontSizeBase: 28
+  m_fontSize: 26
+  m_fontSizeBase: 26
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -151,7 +151,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!224 &3670959205517650161
 RectTransform:
   m_ObjectHideFlags: 0
@@ -376,7 +376,7 @@ RectTransform:
   m_GameObject: {fileID: 2097956155836271747}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 2.23, y: 0.5, z: 1}
+  m_LocalScale: {x: 2.62025, y: 0.69023436, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 2495159770772735569}
@@ -490,7 +490,7 @@ RectTransform:
   m_GameObject: {fileID: 4776216575310901984}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_LocalScale: {x: 1, y: 1.4540623, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 4935504826389192380}
@@ -498,7 +498,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -0.14, y: -101.82}
+  m_AnchoredPosition: {x: -0.14, y: -95}
   m_SizeDelta: {x: 226.022, y: 54.437}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &546653402698875519
@@ -658,7 +658,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 2.664, y: 11.846}
+  m_AnchoredPosition: {x: 2.664, y: 35}
   m_SizeDelta: {x: 150.204, y: 172.904}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!222 &8467523759085557629

--- a/Assets/Scripts/Inventory.cs
+++ b/Assets/Scripts/Inventory.cs
@@ -100,7 +100,7 @@ public class Inventory : MonoBehaviour
     }
 
 
-    private int selectedIndex = -1;
+    private int selectedIndex = 0;
 
     public int SelectedIndex
     {

--- a/Assets/Scripts/Inventory.cs
+++ b/Assets/Scripts/Inventory.cs
@@ -68,6 +68,8 @@ public class Inventory : MonoBehaviour
         if (itemDictionary.TryGetValue(itemData, out InventoryItem item))
         {
             // item.AddToStack();
+            InventoryItem newItem = new InventoryItem(itemData);
+            inventory.Add(newItem);
             Debug.Log($"Added {itemData.itemName} to the inventory. Stack size: {item.stackSize}");
             OnInventoryChange?.Invoke(inventory);
         }

--- a/Assets/Scripts/Inventory.cs
+++ b/Assets/Scripts/Inventory.cs
@@ -67,7 +67,7 @@ public class Inventory : MonoBehaviour
 
         if (itemDictionary.TryGetValue(itemData, out InventoryItem item))
         {
-            item.AddToStack();
+            // item.AddToStack();
             Debug.Log($"Added {itemData.itemName} to the inventory. Stack size: {item.stackSize}");
             OnInventoryChange?.Invoke(inventory);
         }

--- a/Assets/Scripts/InventoryManagement.cs
+++ b/Assets/Scripts/InventoryManagement.cs
@@ -22,6 +22,21 @@ public class InventoryManagement : MonoBehaviour
 
     private void Update()
     {
+        // Check for mouse scroll wheel input
+        float scrollWheelInput = Input.GetAxis("Mouse ScrollWheel");
+
+        // Adjust the selected index based on the scroll wheel input
+        if (scrollWheelInput > 0f)
+        {
+            // Scroll up, select the previous item
+            Inventory.Instance.SelectedIndex = Mathf.Clamp(Inventory.Instance.SelectedIndex - 1, 0, Inventory.Instance.inventory.Count - 1);
+        }
+        else if (scrollWheelInput < 0f)
+        {
+            // Scroll down, select the next item
+            Inventory.Instance.SelectedIndex = Mathf.Clamp(Inventory.Instance.SelectedIndex + 1, 0, Inventory.Instance.inventory.Count - 1);
+        }
+
         // Handle slot selection based on player input (1-5)
         for (int i = 0; i < inventorySlots.Count; i++)
         {
@@ -30,6 +45,7 @@ public class InventoryManagement : MonoBehaviour
                 Inventory.Instance.SelectedIndex = i;
             }
         }
+
 
         // Update slot appearance based on selection
         UpdateSlotSelection();
@@ -87,6 +103,6 @@ public class InventoryManagement : MonoBehaviour
         {
             inventorySlots[i].SelectSlot(i == Inventory.Instance.SelectedIndex);
         }
-    }   
+    }
 
 }


### PR DESCRIPTION
- Add item to stack feature removed (disabled)
- User can grab multiple of same item, only if there is empty slots to hold them (1 item per slot)
- User automatically selects first slot when item is picked up
- User can use the scrollbar to select any active inventory slots
- Slot prefab expanded to fit larger item descriptions